### PR TITLE
Update design docs per feedback

### DIFF
--- a/01_game_vision_and_pillars.md
+++ b/01_game_vision_and_pillars.md
@@ -18,7 +18,7 @@ The skill is in preparation: army composition, equipment choices, and the orders
 
 ## Design Pillars
 
-### 1. LLM Commander (Core Differentiator)
+### 1. LLM Commander (V1 Differentiator, Experimental)
 
 Players don't write detailed scripts—they issue natural language orders to an AI commander who interprets intent and directs units.
 
@@ -37,7 +37,7 @@ Players don't write detailed scripts—they issue natural language orders to an 
 - Creates emergent gameplay (LLM interpretation adds variance)
 - Benchmark potential (compare LLM performance)
 
-**Optional:** Players who prefer full control can disable the Commander and script units directly.
+**Status (v1):** Highly experimental and included in v1. See `06_llm_commander.md` for opt-out and balance policy.
 
 **Note:** The Commander (server-side, game-managed) is distinct from the LLM Assistant (client-side MCP integration for power users). See LLM Commander doc for details.
 
@@ -137,7 +137,7 @@ Every battle produces a complete event log. Replays are authoritative playback o
 - Core battle system (tick-based, deterministic resolution)
 - 2 factions (Humans, Orcs) with distinct rosters
 - Point-buy army builder
-- Natural language order system with LLM Commander interpretation (optional—players can script directly)
+- Natural language order system with LLM Commander interpretation (see `06_llm_commander.md` for opt-out policy)
 - Server-side battle resolution with LLM adaptation
 - Async multiplayer (challenge friend)
 - Replay viewer with full playback controls

--- a/02_battle_system.md
+++ b/02_battle_system.md
@@ -15,8 +15,6 @@ The battle system is the core simulation engine that resolves combat between two
 - Support LLM Commander intervention at defined points
 - Rich enough to reward army composition and order quality
 
-**Open Question:** How does the LLM Commander function in offline single-player? Options include: requiring internet for Commander features, bundling a local model, or limiting single-player to scripted-only mode.
-
 ---
 
 ## Tick-Based Resolution
@@ -236,7 +234,7 @@ Below are starting action types. The full game will support many more.
 
 ### Action Costs (Placeholder Reference)
 
-The following are **placeholder values** from the prototype. These unit types are not intended for the final game—they serve as reference points for understanding the system. Actual rosters will be defined in the Factions doc.
+The following are **placeholder values** from the prototype. These unit types are not intended for the final game—they serve as reference points for understanding the system. Actual rosters will be defined in content data.
 
 | Unit Type | Move | Attack | Wait |
 |-----------|------|--------|------|
@@ -658,16 +656,15 @@ The replayer reconstructs the battle from the event log alone:
 
 ## Open Questions
 
-1. **Offline LLM Commander**: How to handle Commander in offline single-player?
-2. **Wounds system details**: Which wounds exist? Thresholds? Recovery?
-3. **Stamina tuning**: Depletion rates, recovery, effect severity?
-4. **Trampling mechanics**: Size thresholds, push rules, damage?
-5. **Precision system**: How does precision scale with range? Environmental factors?
-6. **Morale thresholds**: What triggers morale checks? Break points?
-7. **Rally mechanics**: Radius, cooldown, requirements?
-8. **Commander intervention model**: Best trigger combination?
-9. **Large unit melee range**: How does size map to reach?
-10. **Squad upgrade limits**: How many upgrades per squad? Point costs?
+1. **Wounds system details**: Which wounds exist? Thresholds? Recovery?
+2. **Stamina tuning**: Depletion rates, recovery, effect severity?
+3. **Trampling mechanics**: Size thresholds, push rules, damage?
+4. **Precision system**: How does precision scale with range? Environmental factors?
+5. **Morale thresholds**: What triggers morale checks? Break points?
+6. **Rally mechanics**: Radius, cooldown, requirements?
+7. **Commander intervention model**: Best trigger combination?
+8. **Large unit melee range**: How does size map to reach?
+9. **Squad upgrade limits**: How many upgrades per squad? Point costs?
 
 ---
 

--- a/03_units_and_abilities.md
+++ b/03_units_and_abilities.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the **framework** for unit stats, equipment, abilities, and related systems. It does not enumerate every specific unit, ability, or status effect—those will number in the hundreds and are defined elsewhere (Factions doc, content databases).
+This document defines the **framework** for unit stats, equipment, abilities, and related systems. It does not enumerate every specific unit, ability, or status effect—those will number in the hundreds and are defined elsewhere (content databases).
 
 ---
 
@@ -73,7 +73,7 @@ There are **8 schools** organized into two categories:
 
 ### Proficiency
 
-- **Regular units**: Never proficient in magic schools
+- **Regular units**: Never proficient in magic schools. They do not cast spells; any magical-like attacks are natural abilities in their action cycle.
 - **Heroes**: May have proficiency in one or more schools
 
 Proficiency is measured as a **skill level**:

--- a/04_army_building.md
+++ b/04_army_building.md
@@ -140,7 +140,7 @@ Gems are purchased during army building and consumed on use.
 
 Gems have a second use: **temporarily empowering casters** during battle to cast spells beyond their normal capability.
 
-*(Full gem mechanics detailed in Magic System doc)*
+*(Full gem mechanics TBD)*
 
 ---
 
@@ -231,7 +231,7 @@ Some units are **unique**—only one per army:
 
 Unique units are **good value for points**—their power justifies their cost. The constraint is uniqueness itself, not inflated pricing.
 
-Unique status is per-army. The faction restriction (below) prevents both players from fielding the same faction's unique units.
+Unique status is enforced per side only. Mirror matches are allowed; each player can independently field their faction's unique units, but no duplicates within a single army.
 
 ---
 
@@ -241,11 +241,6 @@ Unique status is per-army. The faction restriction (below) prevents both players
 
 - At least **one squad**
 - This can be a single hero with no retinue (armies of one are legal)
-
-### Faction Restriction
-
-- Both players **cannot choose the same faction** (for v1)
-- May revisit for mirror matches later
 
 ### No Other Restrictions
 
@@ -295,5 +290,3 @@ Significant balancing work required by developers to ensure diverse viable strat
 ## References
 
 - `03_units_and_abilities.md` — Equipment slots, chassis system
-- `04_factions.md` — Faction rosters and affinities (TBD)
-- Magic System doc — Gem mechanics, spell requirements (TBD)

--- a/05_scripting_and_orders.md
+++ b/05_scripting_and_orders.md
@@ -28,7 +28,7 @@ Troop squads primarily rely on coded AI. Hero squads are where the LLM Commander
 
 4. **The LLM Commander reduces tedium, not skill** — Commander handles boring conditional logic (immunity detection, resource pacing) so players focus on strategy rather than exhaustive edge-case scripting.
 
-5. **Manual scripting is viable but opt-in** — Players who want full control can disable the Commander and script everything. This is harder but deterministic.
+5. **Manual scripting is viable** — Players who want full control can script everything. See `06_llm_commander.md` for opt-out policy and balance assumptions.
 
 6. **Scripts don't assume enemy knowledge** — You can target enemy *types* (mages, cavalry, large units) but not specific enemy unit IDs. No scouting or pre-battle intel required.
 
@@ -233,7 +233,7 @@ What happens when intended actions fail.
 
 - Condition complexity limits for manual scripters
 - Whether squad upgrades unlock new scripting options
-- Order templates and sharing
+- Order template sharing UX (templates are supported; sharing format TBD)
 - Opponent script visibility in replays
 - Cross-faction scripting differences (if any)
 

--- a/06_llm_commander.md
+++ b/06_llm_commander.md
@@ -4,7 +4,17 @@
 
 The LLM Commander is the AI system that interprets player orders and directs unit behavior during battle. It serves as an abstraction layer between high-level player intent and low-level unit scripts, removing the need for players to be programmers while preserving strategic depth.
 
-This is a **core pillar** of the game, not an optional feature.
+This is included in v1 and intentionally experimental. See Policy Summary for opt-out and balance details.
+
+---
+
+## Policy Summary (V1)
+
+- Included in v1 as a major differentiator; intentionally experimental
+- Commander runs server-side for battle resolution; players cannot bring their own LLM for battles
+- Opt-out allowed at any time; mixed matches supported
+- Balance assumes Commander-enabled play; if opt-out dominates, the Commander needs improvement
+- Offline mode uses scripted-only behavior (Commander unavailable)
 
 ---
 
@@ -51,7 +61,7 @@ Some players prefer full control and may disable the LLM Commander entirely. The
 - Have complete determinism in their unit behavior (no LLM adaptation)
 - Trade flexibility for predictability
 
-The game should be designed so that the Commander provides clear benefits (adaptation, convenience) that make most players *want* to use it, while respecting that some players prefer manual control.
+Opt-out is allowed at any time. The game should be designed so that the Commander provides clear benefits (adaptation, convenience) that make most players *want* to use it, while respecting that some players prefer manual control. If opting out is consistently stronger, that signals the Commander needs improvement.
 
 ---
 
@@ -91,7 +101,7 @@ Before battle resolution begins, players submit orders to their LLM Commander.
 Orders are **natural language prompts**, just like any other LLM interaction. Players write orders the way they would instruct a human general.
 
 **Order management features:**
-- **Save/load prompts** - Players can save successful order sets and reuse them
+- **Save/load prompts** - Players can save successful order sets and reuse them (standalone or as part of a full army setup)
 - **Prompt review (optional)** - Before final submission, players can request the Commander show how it interprets the orders. This allows refinement before committing to battle.
 
 ### Interpretation Output
@@ -272,8 +282,6 @@ LLM inference has real costs. The system must balance responsiveness with sustai
 3. **Learning/feedback** - Should the system help players write better orders? ("Your order 'attack' is vague—consider specifying targets")
 
 4. **Fallback behavior** - What happens if LLM call fails mid-battle? Continue with existing scripts? Pause? Default behaviors?
-
-6. **Commander vs. no-Commander matchmaking** - Should players using the Commander be matched separately from those who opt out? Or is mixed matchmaking fine?
 
 ---
 

--- a/07_multiplayer_and_match_flow.md
+++ b/07_multiplayer_and_match_flow.md
@@ -63,7 +63,7 @@ How long each player has to submit their army.
 - Would need careful balance consideration
 - Good for friendly/casual matches
 
-Map variance is generated per match but both players see the same battlefield.
+Map variance is generated per match but both players see the same battlefield. The map is revealed when the match begins (lobby opens), before placement and scripting. With a single v1 map, this is effectively a constant for now.
 
 ---
 
@@ -111,7 +111,7 @@ Once submitted, the army cannot be modified.
 - Unit positions in deployment zone
 - Squad scripts (stance, target priority, hero scripts)
 - Army-level orders (natural language for Commander)
-- Commander enabled/disabled flag
+- Commander enabled/disabled flag (see `06_llm_commander.md` for policy)
 
 ### Validation
 
@@ -288,7 +288,11 @@ Army configurations can be **saved and loaded**:
 Saves include:
 - Army composition
 - All upgrades and items
-- **Do not include:** placement, scripts (these are per-match)
+- Placement in the deployment zone
+- Squad scripts and hero scripts
+- Army-level orders / Commander prompts (if enabled)
+
+Players can also save/load individual scripts and Commander prompts independently as templates.
 
 Useful for:
 - Quickly fielding a favorite army
@@ -347,7 +351,7 @@ Playing without server connection.
 4. Watch replay
 
 **Limitations:**
-- **No LLM Commander** — Local hardware unlikely to support it
+- **No LLM Commander** — Offline mode uses scripted-only behavior (see `06_llm_commander.md`)
 - AI uses scripted behavior only (no adaptive Commander decisions)
 - Less dynamic battles
 


### PR DESCRIPTION
## Summary
- Align LLM Commander policy and opt-out messaging across docs
- Remove deprecated Factions/Magic doc references and mirror-match restriction
- Clarify save semantics and map reveal timing

## Testing
- Not run (docs-only changes)