### PR TITLE
Add V1 architecture and roadmap docs

### DIFF
--- a/docs/architecture/v1_architecture.md
+++ b/docs/architecture/v1_architecture.md
@@ -1,0 +1,467 @@
+# Fantasy Autobattler (V1) — Architecture
+
+**Document status:** Draft  
+**Last updated:** 2026-02-02  
+**Audience:** Project owner (human), multi-agent developers, future contributors
+
+---
+
+## 1. Purpose and scope
+
+This document describes a pragmatic V1 architecture for a fantasy autobattler with:
+
+- Tick-based battle resolution producing an **authoritative event log**
+- **Deterministic replay playback** from the event log (no re-simulation in the viewer)
+- **Asynchronous multiplayer** (submit independently → server resolves)
+- Optional, server-side **LLM Commander** that interprets player orders and intervenes at bounded points
+- A **Desktop Application** that contains both **Army Building** and **Replay Viewing** in one cohesive UX
+- Optional **External Assistant integration** (MCP) useful for development and power users
+
+V1 assumes modest load (e.g., ≤ ~1k battles/day at launch), so the deployment can be intentionally simple while retaining clean boundaries.
+
+---
+
+## 2. Core requirements (V1)
+
+### Functional
+- Two factions in V1 (Humans, Orcs), data-driven roster
+- Point-buy army building
+- Deployment placement inside zones
+- Squad scripting (troops: stance + target priority; heroes: opening actions + conditions + default behavior)
+- Battle resolution:
+  - supports ~2000 total combatants
+  - seeded RNG for deterministic testing
+  - event log output
+- Replay:
+  - play/pause/seek/speed/step
+  - unit inspection
+  - battle summary
+  - visibility into LLM Commander decisions (summaries + patches)
+- Multiplayer async:
+  - match creation/join
+  - submission
+  - resolve when both submitted
+  - replay retrieval
+
+### Non-functional
+- Deterministic log order: stable `(tick, seq)` ordering
+- Performance: battle worker must complete typical battles quickly enough for async UX
+- Logs must be compact enough to store/share
+- The desktop app must render 2000 units + projectiles smoothly (with placeholder art first)
+
+---
+
+## 3. High-level system overview
+
+### Components
+
+- **Desktop App** (single application):
+  - Match Hub (browse/pending/results)
+  - Army Builder (roster, upgrades, scripts, placement)
+  - Replay Viewer (event-log playback)
+  - Local storage (saves, cached replays)
+  - Optional External Assistant bridge (dev-mode / power-user)
+  - Offline resolver (same sim core, Commander disabled)
+
+- **Backend** (server):
+  - API (auth, match lifecycle, replay access)
+  - Battle Worker (authoritative resolution + log generation)
+  - LLM Commander module/service (invoked by worker)
+  - Notification (email optional for V1)
+  - Postgres + object storage + Redis (queue/caching)
+
+### System diagram
+
+```mermaid
+flowchart LR
+  subgraph Desktop["Desktop App (single UX)"]
+    HUB["Match Hub"]
+    AB["Army Builder"]
+    RV["Replay Viewer"]
+    LS["Local Storage (SQLite + files)"]
+    EA["External Assistant Bridge (optional)"]
+    OFF["Offline Resolver (no LLM)"]
+    CORE["Battle Core Library (shared)"]
+    HUB --- AB
+    HUB --- RV
+    AB --- LS
+    RV --- LS
+    EA --- AB
+    EA --- RV
+    OFF --- CORE
+    AB --- CORE
+    RV --- CORE
+  end
+
+  subgraph Server["Backend"]
+    API["HTTP API"]
+    MATCH["Match/State Machine"]
+    QUEUE["Job Queue"]
+    WORKER["Battle Worker"]
+    CMD["LLM Commander"]
+    NOTIF["Notifications (optional)"]
+  end
+
+  subgraph Data["Data Stores"]
+    DB["Postgres"]
+    OBJ["Object Storage (S3-compatible)"]
+    REDIS["Redis (queue/cache)"]
+  end
+
+  subgraph LLM["LLM Provider"]
+    LLMAPI["LLM API"]
+  end
+
+  Desktop <-->|HTTPS| API
+  API --> MATCH
+  MATCH --> DB
+  API --> DB
+
+  MATCH --> QUEUE
+  QUEUE --> WORKER
+  WORKER --> CMD
+  CMD --> LLMAPI
+
+  WORKER --> OBJ
+  WORKER --> DB
+  NOTIF --> DB
+  QUEUE <--> REDIS
+  API <--> REDIS
+```
+
+---
+
+## 4. Desktop App architecture (subsystems)
+
+The Desktop App is the primary product surface: users build armies and watch replays in one cohesive UX.
+
+### 4.1 Subsystems
+
+1. **Match Hub**
+   - Login/identity UI (online mode)
+   - Match list (pending / ready to watch / history)
+   - Create/Join/Challenge (V1 can be friend-only)
+
+2. **Army Builder**
+   - Data-driven roster browser
+   - Point budget accounting + validation
+   - Squad purchase + upgrades
+   - Hero equipment + empowerment + gems
+   - Placement editor (deployment zones)
+   - Scripting editor (troop + hero)
+   - Commander orders UI (optional toggle)
+   - Submit to server (online) or Run locally (offline)
+
+3. **Replay Viewer**
+   - Load event log (local cache or streamed download)
+   - Playback controls (play/pause/seek/speed/step)
+   - Timeline markers (kills, routs, commander interventions)
+   - Unit inspection (tile list, hero finder)
+   - Battle summary
+
+4. **Local Storage**
+   - SQLite for:
+     - saved armies/templates
+     - local match metadata
+     - cached replay index + pointers to files
+   - Filesystem cache for:
+     - replay logs (compressed)
+     - art assets (sprite atlases, audio)
+
+5. **External Assistant Bridge (optional)**
+   - Dev-mode harness for automated playtesting:
+     - generate armies
+     - run local battles
+     - export replays
+     - run bulk simulations and summarize outcomes
+   - Power-user mode (optional) for army-building assistance via MCP
+
+6. **Offline Resolver**
+   - Runs the same battle core locally
+   - Commander disabled (or mock deterministic commander)
+   - Produces event logs that are replayable in the same viewer
+
+### 4.2 Desktop internal diagram
+
+```mermaid
+flowchart TB
+  subgraph UI["UI Layer (React)"]
+    HUB["Match Hub Screens"]
+    BUILD["Army Builder Screens"]
+    REPLAY["Replay Viewer Screens"]
+  end
+
+  subgraph APP["Desktop Runtime (Tauri)"]
+    APIClient["Online API Client"]
+    Commands["Tauri Commands (Rust)"]
+    Storage["Local Storage (SQLite + FS)"]
+    Assistant["Assistant Bridge (optional)"]
+  end
+
+  subgraph CORE["Battle Core (Rust Library)"]
+    Sim["Resolver"]
+    LogEnc["Event Log Encoder"]
+    LogDec["Event Log Decoder"]
+    Content["Content Loader (units/items/spells)"]
+  end
+
+  HUB --> APIClient
+  BUILD --> Commands
+  REPLAY --> Commands
+
+  Commands --> Storage
+  Commands --> Sim
+  Sim --> LogEnc
+  LogDec --> REPLAY
+  Content --> Sim
+  Content --> BUILD
+
+  Assistant --> Commands
+```
+
+**Key principle:** keep game logic out of UI components. UI calls Tauri commands, which invoke the shared core (resolver/log codecs/content) and storage.
+
+---
+
+## 5. Battle resolution design (shared core)
+
+### 5.1 Resolver loop
+
+Although the design uses “ticks,” the implementation should avoid scanning all units every tick. Instead:
+
+- Maintain time-indexed schedules:
+  - next unit action tick
+  - projectile impact tick
+  - effect expiration tick
+- Advance to the next tick where something occurs (“jump to next event tick”)
+- Within a tick, resolve deterministically:
+  1. impacts + expirations
+  2. unit actions (stable order: unit_id)
+  3. commander intervention (if triggered at this tick)
+
+This preserves the “tick” abstraction while scaling better.
+
+### 5.2 Determinism
+
+- Seeded PRNG for all non-LLM randomness
+- Stable ordering: events are `(tick, seq)` in emission order
+- Event log is the authoritative record
+
+**Testing mode:** a mock commander can be deterministic to allow reproducible results end-to-end.
+
+---
+
+## 6. Event log format and replay
+
+### 6.1 Goals
+- Compact
+- Streamable (don’t require full log in memory)
+- Versioned and forwards-tolerant (within reason)
+
+### 6.2 Recommended format (V1)
+- Protobuf messages (schema)
+- Length-delimited streaming file
+- Compression: zstd
+- Optional index chunk for fast seeking
+
+### 6.3 Replay principles
+- The replayer does **not** run resolver logic
+- It reconstructs render state by applying events sequentially
+- Any “derived” state (HP bars, effects) must be derivable from events alone
+
+---
+
+## 7. Backend architecture (V1)
+
+### 7.1 Keep it simple at launch
+Given expected low battle volume, a minimal deployment can be:
+
+- 1× API service (includes match state machine)
+- 1× Worker service (battle jobs)
+- Postgres
+- Redis (queue)
+- Object storage (event logs)
+
+You can run API + Worker on small instances and scale workers horizontally if needed later.
+
+### 7.2 Match state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Created
+  Created --> LobbyOpen: opponent joins
+  LobbyOpen --> A_Submitted: A submits
+  LobbyOpen --> B_Submitted: B submits
+  A_Submitted --> Both_Submitted: B submits
+  B_Submitted --> Both_Submitted: A submits
+  Both_Submitted --> Resolving: enqueue job
+  Resolving --> Complete: log stored + result saved
+  LobbyOpen --> Forfeit: timeout
+  A_Submitted --> Forfeit: timeout
+  B_Submitted --> Forfeit: timeout
+  Complete --> [*]
+  Forfeit --> [*]
+```
+
+### 7.3 Online flow sequence
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Desktop App
+  participant API as Server API
+  participant DB as Postgres
+  participant Q as Queue
+  participant W as Worker
+  participant S as Object Storage
+
+  C->>API: create/join match
+  API->>DB: persist match state
+  C->>API: submit army + scripts + orders
+  API->>DB: save submission
+  API->>Q: enqueue battle job when both submitted
+  Q->>W: job(match_id)
+  W->>DB: load match + submissions
+  W->>W: resolve battle + produce event log
+  W->>S: upload event log
+  W->>DB: save summary + artifact ref
+  C->>API: fetch result + replay reference
+  API->>S: signed URL / stream
+  API-->>C: replay download/stream
+```
+
+---
+
+## 8. Auth and identity (V1)
+
+Auth is required for online async multiplayer but can be minimal:
+
+- **Passwordless email code/magic link** is simplest for early alpha.
+- Store user identity in Postgres:
+  - `users(id, email, created_at, ...)`
+  - sessions/tokens as needed
+- All match participation is keyed by user_id.
+
+Offline mode requires no auth.
+
+---
+
+## 9. LLM Commander architecture (bounded)
+
+### 9.1 Two-phase model
+
+1) **Pre-battle interpretation (1 call per side)**
+- Input: player orders + roster + allowed script primitives
+- Output:
+  - initial scripts
+  - adaptation rules (what triggers interventions)
+  - human-readable summary
+- Logged in event log (`CommanderOrdersReceived`, `CommanderInterpretation`)
+
+2) **During battle interventions (bounded)**
+- Triggered by:
+  - cadence (every N ticks)
+  - events (e.g., “archers threatened”, “immunity observed”)
+  - strict budget (e.g., 3 interventions per side)
+- Output: structured script patches only (not free-form commands)
+- Logged as `CommanderIntervention` with:
+  - trigger
+  - patch summary
+  - brief reasoning text for replay
+
+### 9.2 Failure behavior
+If the commander call fails (timeout, invalid output):
+- Continue with existing scripts
+- Log a commander error event (optional)
+
+---
+
+## 10. External Assistant (MCP) integration
+
+### 10.1 Dev harness (recommended early)
+Use MCP to let development agents “playtest” programmatically:
+- query roster and stats
+- construct armies
+- configure scripts
+- run local battles (offline)
+- batch simulate (e.g., 100 runs) and summarize
+
+### 10.2 Security and release policy
+- Default: dev tools disabled in public builds
+- Alpha/beta: behind an explicit “Developer Mode” flag
+- Never expose opponent data or active-battle control via the assistant
+
+---
+
+## 11. Data model (high level)
+
+### Tables (suggested)
+- `users`
+- `matches`
+- `match_players`
+- `submissions`
+- `battle_artifacts` (event log ref + schema versions)
+- `notifications` (optional)
+
+### Storage
+- Postgres: metadata and state
+- Object storage: event logs, optional replay previews
+
+---
+
+## 12. Tech stack recommendation (V1)
+
+### Desktop App
+- Tauri (Rust backend) + React/TypeScript frontend
+- Renderer: PixiJS (WebGL 2D) for sprites/projectiles
+- Audio: Web Audio API + simple asset pipeline
+- Local persistence: SQLite + filesystem cache
+
+### Shared core
+- Rust crates:
+  - `battle_core` (resolver)
+  - `battle_formats` (event log schema + codecs)
+  - `content` (data loaders)
+
+### Backend
+- Rust (Axum) API and Worker
+- Postgres
+- Redis queue
+- S3-compatible object storage
+- Email service (optional for V1)
+
+---
+
+## 13. CI/CD (summary; details in Roadmap doc)
+
+- PR CI: lint/format/tests + determinism “golden log” checks
+- Nightly builds:
+  - desktop artifacts per OS
+  - optional dev-mode assistant bridge included
+- Tagged releases:
+  - signed/notarized builds for external testers
+- Backend:
+  - container build + deploy
+  - migrations validated in CI
+
+---
+
+## 14. Open decisions (tracked in issues)
+- Event log: include seek index in V1 or add later?
+- How much state summary is logged for commander interventions?
+- Minimum UX for hero scripting editor in V1
+- Which mechanics are required for “fun” early (morale, stamina, wounds)
+
+---
+
+## Appendix A: “Minimum viable playable loop” (offline)
+
+1. Choose faction
+2. Buy squads (point budget)
+3. Place in deployment zone
+4. Set basic scripts (stance + target priorities)
+5. Run local battle
+6. Watch replay
+7. Iterate
+
+This loop should be achievable before online multiplayer and before real art.

--- a/docs/planning/v1_roadmap.md
+++ b/docs/planning/v1_roadmap.md
@@ -1,0 +1,389 @@
+# Fantasy Autobattler (V1) — Roadmap (No Timelines)
+
+**Document status:** Draft  
+**Last updated:** 2026-02-02  
+**Audience:** Project owner (human), multi-agent developers
+
+This roadmap is organized by milestones and relative effort, not dates. Each milestone ends in a demoable artifact.
+
+---
+
+## 1. Project management approach (multi-agent)
+
+### 1.1 Tracking system
+Use **GitHub Issues + GitHub Projects** (single Project for V1).
+
+- Parent issues represent **deliverables** (epics/specs)
+- Sub-issues represent **implementation tasks** (parallelizable)
+- Dependencies are modeled explicitly when sequencing matters
+
+### 1.2 Issue state (“in development”)
+Issues are open/closed, but the Project adds a **Status** field to represent states:
+
+- Backlog
+- Ready
+- In Progress
+- In Review
+- Blocked
+- Done
+
+**Multi-agent rule:** Agents pull only from **Ready**, then assign themselves and move to **In Progress** immediately.
+
+### 1.3 UX ticket pattern
+Yes, treat UX work as real deliverables:
+
+- Parent issue: UX spec/deliverable with acceptance criteria + artifact links
+- Sub-issues: implementation steps, polish passes, usability fixes
+
+### 1.4 Definition of Done (recommended)
+An issue is “Done” when:
+- Acceptance criteria met
+- Tests updated/added (where applicable)
+- Determinism preserved (if touching sim/log)
+- Performance concerns noted (if relevant)
+- PR linked and merged
+- Documentation updated if it changes public behavior or formats
+
+---
+
+## 2. Milestones overview
+
+Effort scale: **XS / S / M / L / XL**  
+Each milestone lists: Outcome, Scope, Dependencies, Exit Criteria.
+
+---
+
+## M0 — Foundations and guardrails (S)
+
+### Outcome
+Agents can work safely with minimal coordination overhead.
+
+### Scope
+- Repo structure for desktop + core + server
+- CI skeleton (lint/format/test)
+- Basic “hello world” desktop app build
+- Basic “hello world” battle_core CLI
+- Issue templates + Project fields + labels
+- Coding conventions and PR rules (small PRs, tests, linking)
+
+### Exit criteria
+- A PR can be opened and CI runs reliably
+- Desktop app builds locally
+- Core library builds + tests run
+
+---
+
+## M1 — Battle core MVP + deterministic event log (L)
+
+### Outcome
+A headless battle can run locally and produce an event log that can be decoded.
+
+### Scope
+- Minimal unit model:
+  - positions, move, melee, ranged projectile, death
+- Seeded RNG
+- Event schema + encoder/decoder
+- Determinism tests:
+  - golden log hash for known scenario
+- Performance harness:
+  - 2000 units stress case
+- Content stub:
+  - placeholder unit definitions (data-driven skeleton)
+
+### Dependencies
+- M0
+
+### Exit criteria
+- `battle_core` runs a sample battle and outputs a replayable log
+- Determinism test passes in CI
+
+---
+
+## M2 — Desktop Replay Viewer MVP (L)
+
+### Outcome
+The desktop app can load an event log and play it back smoothly.
+
+### Scope
+- Event log ingestion (local file)
+- Playback controls:
+  - play/pause, speed, seek, step
+- WebGL renderer:
+  - 2k units placeholder sprites
+  - projectiles as sprites/particles
+- Unit inspection:
+  - click tile → list units
+- Basic battle summary UI (placeholder stats)
+
+### Dependencies
+- M1
+
+### Exit criteria
+- Replay viewer plays the M1 golden log end-to-end at multiple speeds
+- Stress replay with 2000 units stays responsive on target machines
+
+---
+
+## M3 — Offline “Playable Loop” (XL)
+
+### Outcome
+Users can build an army, run a local battle, and watch the replay — all inside the desktop app.
+
+### Scope
+- Army Builder MVP:
+  - point budget
+  - buy squads + upgrades (minimal)
+  - placement in deployment zones
+  - troop scripts: stance + target priority
+- Local validation errors are actionable
+- Run local resolver and immediately open replay viewer
+- Save/load army configs (simple)
+
+### Dependencies
+- M1, M2
+
+### Exit criteria
+- A non-developer can do: build → run → replay → iterate
+- This becomes the main development playtest loop
+
+---
+
+## M4 — Data-driven content slice: Humans vs Orcs (L–XL)
+
+### Outcome
+Two factions exist as real content (even if small).
+
+### Scope
+- Content format finalized (units/squads/items/spells minimal set)
+- Data loaders integrated in both builder and resolver
+- Minimal roster per faction:
+  - infantry, archers, cavalry, one mage/hero
+- Initial balance knobs:
+  - point costs, basic stats
+
+### Dependencies
+- M3 (so content can be playtested immediately)
+
+### Exit criteria
+- Humans vs Orcs offline matches are playable and interesting
+- Changes to content do not require code edits (mostly data-only)
+
+---
+
+## M5 — Online async multiplayer skeleton (XL)
+
+### Outcome
+End-to-end online match flow works:
+create/join → submit → resolve → fetch replay.
+
+### Scope
+- Backend API:
+  - match creation/join
+  - submission
+  - match list/history
+  - replay access (download/stream)
+- Worker:
+  - run resolver server-side
+  - store logs in object storage
+- Minimal anti-footgun validation server-side (budget, placement bounds)
+- Desktop:
+  - basic online lobby + submit + results screen
+
+### Dependencies
+- M3, M4 (so you already have a fun offline experience)
+
+### Exit criteria
+- Two real machines can complete a match asynchronously
+- Result is durable; replay can be watched later
+
+---
+
+## M6 — Auth + identity for alpha (M–L)
+
+### Outcome
+Online play has reliable identity and permissions.
+
+### Scope
+- Minimal auth method (recommended: email code/magic link)
+- User profile basics
+- Permission checks:
+  - only match participants can submit/view private matches
+- Rate limiting on auth endpoints
+- Admin/dev override for internal testing (optional)
+
+### Dependencies
+- M5 (or can be built alongside M5 if you prefer)
+
+### Exit criteria
+- Alpha testers can log in and play without manual DB setup
+
+---
+
+## M7 — LLM Commander V1 (L–XL)
+
+### Outcome
+The differentiator exists: orders → scripts, bounded interventions, visible in replay.
+
+### Scope
+- Pre-battle interpretation:
+  - orders → scripts + summary
+  - log orders + interpretation
+- Intervention system:
+  - event triggers + strict budget
+  - structured patch outputs only
+  - log interventions with brief reasoning
+- Replay UI:
+  - timeline markers for interventions
+  - viewer panel showing “what changed” (at least high level)
+
+### Dependencies
+- M3 (offline loop) and ideally M5/M6 (online makes it meaningful)
+
+### Exit criteria
+- Commander produces understandable behavior changes
+- Interventions are visible and not spammy
+- Failure mode is safe (no battle break)
+
+---
+
+## M8 — External Assistant (MCP) for dev + power users (M–L)
+
+### Outcome
+Agents (and optionally power users) can interact with the game via tool calls to build armies, run battles, and analyze replays.
+
+### Scope
+- MCP server/bridge in dev mode
+- Tool surface for:
+  - listing content
+  - constructing armies
+  - setting scripts
+  - running local battles
+  - exporting replay bundles and summary stats
+- Gate in release builds:
+  - hidden behind “Developer Mode”
+
+### Dependencies
+- M3 (needs the builder + local run loop)
+
+### Exit criteria
+- A dev agent can “playtest” end-to-end without UI clicks
+- Automated playtest scripts can run nightly (optional)
+
+---
+
+## M9 — Alpha distribution + polish pack (XL)
+
+### Outcome
+You can hand builds to external testers on Windows/macOS/Linux with manageable friction.
+
+### Scope
+- Packaging:
+  - Windows installer or portable zip
+  - macOS dmg/app (sign/notarize as needed)
+  - Linux AppImage
+- Crash reporting + basic telemetry (optional but useful)
+- Replay sharing basics (even if just “copy log”)
+- UX polish:
+  - reduce friction in builder and replay viewer
+  - better error messages, empty states
+- Observability:
+  - server logs/metrics sufficient for debugging
+
+### Dependencies
+- M5/M6 (online alpha) or M3 (offline alpha)
+
+### Exit criteria
+- A tester can install/run with minimal coaching
+- A bug report includes enough info to reproduce
+
+---
+
+## 3. Suggested sequencing (why this order)
+
+The fastest path to a real game experience is:
+
+1) Resolver + log (M1)  
+2) Replay viewer (M2)  
+3) Offline playable loop (M3)  
+4) Content slice (M4)  
+5) Online async (M5) + auth (M6)  
+6) Commander (M7)  
+7) Assistant (M8)  
+8) Distribution polish (M9)
+
+This ensures you are iterating on gameplay and UX early, not infrastructure.
+
+---
+
+## 4. Parallelization plan (agents)
+
+After M0, you can run parallel tracks with minimal collision:
+
+- Track A (Core): resolver + log schema + determinism tests
+- Track B (Desktop): replay viewer rendering + playback controls
+- Track C (Desktop): army builder UI + validation + placement
+- Track D (Server): match flow + storage + worker integration
+- Track E (LLM): commander summarizer + patch format + budgets
+- Track F (Content): data definitions + initial factions + balance knobs
+
+The key shared contracts to stabilize early:
+- Event log schema
+- Content data format
+- Minimal API endpoints (once online starts)
+
+---
+
+## 5. CI/CD (practical, lightweight)
+
+### 5.1 PR CI (every pull request)
+- Rust:
+  - fmt, clippy, tests
+- TypeScript:
+  - lint, typecheck, unit tests
+- Determinism:
+  - generate golden battle log and verify hash
+- Optional smoke perf test (loose threshold)
+
+### 5.2 Nightly builds (on main)
+- Build desktop artifacts for Windows/macOS/Linux
+- Attach to GitHub Release as “nightly”
+- Include dev-mode assistant bridge (optional)
+
+### 5.3 Tagged releases (alpha)
+- Signed/notarized builds where feasible
+- Release notes template includes:
+  - known issues
+  - replay compatibility notes (schema/content version)
+
+### 5.4 Backend CD (simple)
+- Build container images for API + Worker
+- Deploy to a small environment
+- Run migrations as part of deploy pipeline (guarded)
+
+---
+
+## 6. Checklist: what “V1 playable” means (definition)
+
+V1 should minimally support:
+- Build armies (two factions)
+- Script squads/heroes (basic)
+- Run online async match
+- Watch replay with clarity
+- Commander optional and visible (if included in V1 scope)
+- Stable enough for repeated playtests and iteration
+
+---
+
+## Appendix: Example top-level epics (issue seeds)
+
+- Epic: Battle Core MVP (M1)
+- Epic: Event Log Schema + Codecs (M1)
+- Epic: Replay Viewer MVP (M2)
+- Epic: Army Builder MVP (M3)
+- Epic: Content Data Model + Loaders (M4)
+- Epic: Humans vs Orcs Content Slice (M4)
+- Epic: Online Match Flow (M5)
+- Epic: Auth (M6)
+- Epic: LLM Commander V1 (M7)
+- Epic: MCP Assistant Bridge (M8)
+- Epic: Alpha Packaging + Distribution (M9)


### PR DESCRIPTION
## Summary
- Add V1 architecture overview
- Add V1 roadmap (milestones and sequencing)

## Testing
- Not run (docs-only changes)