### PR TITLE
M0: Issue templates + project conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,93 @@
+name: Bug Report
+description: Something isn't working as expected.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Provide enough detail to reproduce and verify the fix.
+        After creating the issue, add it to the project board and set Status/Type/Area/Target/Size.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+      placeholder: "Example: Replay playback freezes when seeking past 10,000 ticks."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide exact steps and inputs.
+      placeholder: "1. Open replay viewer\n2. Load replay_2000_units.log\n3. Drag scrubber to 75%"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: "Example: Playback continues with no freeze."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: "Example: UI hangs and CPU spikes to 100%."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0 (blocks work or corrupts data)
+        - P1 (major feature broken)
+        - P2 (degraded but workaround exists)
+        - P3 (minor/edge case)
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, build, commit, and any relevant hardware.
+      placeholder: "Example: Windows 11, commit 1234abcd, RTX 3060"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots / Repro Artifacts
+      description: Paste logs or link to files.
+      placeholder: "Attach crash log or replay file."
+
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression?
+      description: Did this work in a previous build? If yes, name the last known good.
+      placeholder: "Example: Worked in commit 0a1b2c3d"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Fix Verification / Acceptance Criteria
+      description: How will we know it is fixed?
+      placeholder: "Example: Repro steps no longer freeze and playback continues."
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing Plan
+      description: What tests or validation will be done?
+      placeholder: "Example: Add regression test; manual smoke test."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project Board
+    url: https://github.com/users/saykrikan-krap/projects/1
+    about: Check current iteration, status, and priorities.
+  - name: Documentation
+    url: https://github.com/saykrikan-krap/fantasy-autobattler/tree/master/docs
+    about: Architecture, roadmap, and requirements docs.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,94 @@
+name: Feature / Task
+description: New feature or deliverable with clear acceptance criteria.
+title: "[M?] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for product work, tech tasks, and deliverables.
+        Keep the goal concrete and include acceptance criteria that can be verified.
+        After creating the issue, add it to the project board and set Status/Type/Area/Target/Size.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome are we trying to achieve? State it in measurable terms.
+      placeholder: "Example: The desktop app can load a replay log and scrub through it at 2x speed without stutter."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Problem Statement
+      description: Why now? What problem does this solve?
+      placeholder: "Example: We need a minimal replay viewer to validate the event log format."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: In Scope
+      description: Bullet the concrete work included in this issue.
+      placeholder: "- Playback controls\n- Log ingestion\n- Basic render loop"
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out of Scope
+      description: What is explicitly not included to keep this contained?
+      placeholder: "- Sound effects\n- Unit inspection panel"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this to be done? Keep it testable.
+      placeholder: "- Replay loads a golden log and plays end-to-end\n- Seek works within 250ms\n- Unit count stays stable at 2k"
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Open Questions
+      description: Call out unknowns, performance risks, or dependencies.
+      placeholder: "Example: We may need to change the log schema to support seeking."
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Link to blocking issues or external decisions.
+      placeholder: "- #123 (log schema)\n- Asset pipeline decision"
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing Plan
+      description: What tests or validation will be done?
+      placeholder: "Example: Add unit test for log decoding; manual playback smoke test."
+
+  - type: textarea
+    id: docs
+    attributes:
+      label: Documentation Updates
+      description: What docs need to change or be added?
+      placeholder: "Example: Update docs/architecture/v1_architecture.md section 6."
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Confirm the finishing steps that apply.
+      options:
+        - label: Acceptance criteria met
+        - label: Tests updated/added (as applicable)
+        - label: Determinism preserved (if touching sim/log)
+        - label: Docs updated (if behavior or format changes)
+        - label: PR linked and merged

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,79 @@
+name: Spike / Investigation
+description: Timeboxed research to reduce uncertainty.
+title: "[Spike] "
+labels: ["spike"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Spikes should be timeboxed and produce a clear artifact or decision.
+        After creating the issue, add it to the project board and set Status/Type/Area/Target/Size.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question / Hypothesis
+      description: What are we trying to learn or decide?
+      placeholder: "Example: Can we stream event logs with seek support using length-delimited protobuf + zstd?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this spike needed now?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: timebox
+    attributes:
+      label: Timebox
+      options:
+        - 2 hours
+        - 4 hours
+        - 1 day
+        - 2 days
+        - 1 week
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in the investigation?
+      placeholder: "Example: prototype log writer/reader, measure file size, evaluate seek index."
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: Explicitly call out what will not be attempted.
+
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Expected Deliverable
+      description: What artifact should this spike produce?
+      placeholder: "Example: short doc with recommendation + prototype repo link."
+    validations:
+      required: true
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Success Criteria
+      description: What outcome makes the spike successful?
+      placeholder: "Example: choose a log format and document tradeoffs."
+    validations:
+      required: true
+
+  - type: textarea
+    id: followup
+    attributes:
+      label: Follow-up Work
+      description: Issues to file after this spike finishes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+- 
+
+## Context
+- 
+
+## Testing
+- Not run (explain why)
+
+## Checklist
+- [ ] Linked issue(s)
+- [ ] Acceptance criteria met
+- [ ] Tests updated/added (as applicable)
+- [ ] Docs updated (if behavior or format changes)
+- [ ] Determinism preserved (if touching sim/log)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ Fantasy Autobattler is a fantasy-themed autobattle project. The goal is a shared
 
 ## Docs
 - `README.md` for the current repo overview and structure.
-- `docs/` for design notes and longer-form plans.
+- `docs/` for architecture, planning, and project conventions.
+- `docs/project_conventions.md` for issue templates, fields, and workflow rules.
 - GitHub Project `Fantasy Autobattler — Battles Only` for milestones, iteration planning, and task status.
 
 ## Repo Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,4 @@ Fantasy Autobattler is a fantasy-themed autobattle project. The goal is a shared
 3. Create a branch from `master` in your active worktree (example: `issue-<number>-<short-slug>`).
 4. Implement the work and open a PR.
 5. When the PR is ready for review, set the status to `In review`.
-6. After merge and verification, set the status to `Done`.
+6. After merge and verification, set the status to `Done` and close the issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ Fantasy Autobattler is a fantasy-themed autobattle project. The goal is a shared
 - `docs/` for architecture, planning, and project conventions.
 - `docs/project_conventions.md` for issue templates, fields, and workflow rules.
 - GitHub Project `Fantasy Autobattler — Battles Only` for milestones, iteration planning, and task status.
+## Issue Templates & Conventions
+- Use the GitHub issue templates (Feature/Task, Bug, Spike) whenever creating new issues.
+- Follow `docs/project_conventions.md` for required fields, status flow, and Definition of Done expectations.
 
 ## Repo Structure
 - `desktop/`, `core/`, `server/` are the primary product components.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - `desktop/` Desktop app (UI + replay viewer). Placeholder build/config in `desktop/BUILD.stub`, placeholder entry point in `desktop/ENTRYPOINT.stub`.
 - `core/` Shared battle core library. Placeholder build/config in `core/BUILD.stub`, placeholder entry point in `core/ENTRYPOINT.stub`.
 - `server/` Backend services. Placeholder build/config in `server/BUILD.stub`, placeholder entry point in `server/ENTRYPOINT.stub`.
-- `docs/` Architecture and planning docs (see `docs/architecture/v1_architecture.md` and `docs/planning/v1_roadmap.md`).
+- `docs/` Architecture, planning, and conventions (see `docs/architecture/v1_architecture.md`, `docs/planning/v1_roadmap.md`, and `docs/project_conventions.md`).
 - `assets/` Art, audio, and other game assets (to be organized as they arrive).
 - `tools/` Dev tooling, automation, and helper scripts.
 - `infra/` Deployment and infrastructure configuration.

--- a/docs/project_conventions.md
+++ b/docs/project_conventions.md
@@ -18,7 +18,7 @@ Use the issue templates (Feature/Task, Bug, Spike). A ticket is considered **Rea
 - `Ready`: fully scoped, unblocked, and can be picked up
 - `In progress`: actively being worked on (move here before starting)
 - `In review`: PR opened and ready for review
-- `Done`: merged and verified
+- `Done`: merged and verified, and the issue is closed
 
 **Priority**
 - `P0`: blocks work or major milestone
@@ -59,7 +59,7 @@ Use the issue templates (Feature/Task, Bug, Spike). A ticket is considered **Rea
 - Create branches as `issue-<number>-<short-slug>`.
 - Move the issue to `In progress` before starting work.
 - When a PR is ready, move to `In review`.
-- After merge and verification, set to `Done`.
+- After merge and verification, set to `Done` and close the issue.
 
 ## Definition of Done
 - Acceptance criteria met

--- a/docs/project_conventions.md
+++ b/docs/project_conventions.md
@@ -1,0 +1,74 @@
+# Project Conventions
+
+This document standardizes how we create issues and use the project board so work stays consistent and traceable.
+
+## Where Work Is Tracked
+- GitHub Issues are the source of truth for tasks and deliverables.
+- The project board is **Fantasy Autobattler — Battles Only** and is used for iteration planning and status.
+
+## Issue Creation
+Use the issue templates (Feature/Task, Bug, Spike). A ticket is considered **Ready** when it has:
+- A clear goal and scope
+- Acceptance criteria that are testable
+- Any dependencies called out or resolved
+
+## Project Fields (How to Use Them)
+**Status**
+- `Backlog`: not ready or not prioritized yet
+- `Ready`: fully scoped, unblocked, and can be picked up
+- `In progress`: actively being worked on (move here before starting)
+- `In review`: PR opened and ready for review
+- `Done`: merged and verified
+
+**Priority**
+- `P0`: blocks work or major milestone
+- `P1`: important for current milestone/iteration
+- `P2`: useful but not critical
+- `P3`: nice-to-have or deferred
+
+**Size**
+- `XS`: < 2 hours
+- `S`: up to 1 day
+- `M`: 2–3 days
+- `L`: 1 week
+- `XL`: multi-week (should be split)
+
+**Type**
+- `Feature`, `Bug`, `Chore`, `Spike`, `Tech-debt`
+
+**Target**
+- `v1`, `v1.1`, `Later`
+
+**Area**
+- `App`, `Sim`, `Server`, `Tools/Infra`, `Content`
+
+**Subsystem**
+- `Setup`, `Scripting`, `Replay Viewer`, `Results/Report`, `Core UI`, `Input/Controls`, `Assets`, `Networking/Sync`
+
+**Iteration**
+- Assign when the issue is scheduled for the current iteration.
+
+## Labels
+- `bug`, `enhancement`, `spike` align with issue templates.
+- `blocked` indicates a dependency that prevents progress.
+- `v1` indicates current release scope.
+- `good-first-task` marks small, well-scoped tasks suitable for quick pickup.
+- `documentation` for doc-only updates.
+
+## Branching & Status Flow
+- Create branches as `issue-<number>-<short-slug>`.
+- Move the issue to `In progress` before starting work.
+- When a PR is ready, move to `In review`.
+- After merge and verification, set to `Done`.
+
+## Definition of Done
+- Acceptance criteria met
+- Tests updated/added where applicable
+- Determinism preserved if touching sim/log
+- Performance concerns noted (if relevant)
+- PR linked and merged
+- Docs updated if behavior or formats changed
+
+## Session Docs
+- Session docs live in `sessions/` and store agent context for cross-machine work.
+- Prefix the filename with `codex` for Codex agents or `claude` for Claude agents.


### PR DESCRIPTION
## Summary
- Adds issue templates (feature/task, bug, spike) to standardize intake.
- Adds PR template and a `docs/project_conventions.md` guide.
- Updates README and AGENTS to point to the conventions and workflow rules.

Closes #19.

## Context
- We need consistent issue intake and project field usage to keep multi-agent work unblocked.
- M0 calls for templates + conventions so Ready items are truly actionable.

## Testing
- Not run (documentation and templates only).

## Checklist
- [x] Linked issue(s)
- [x] Acceptance criteria met
- [x] Tests updated/added (as applicable)
- [x] Docs updated (if behavior or format changes)
- [x] Determinism preserved (if touching sim/log)
